### PR TITLE
Fix setting reward for comments and displaying reward in profile

### DIFF
--- a/internal/controllers/reward/setcomment.go
+++ b/internal/controllers/reward/setcomment.go
@@ -38,7 +38,7 @@ func SetComment(c *fiber.Ctx) error {
 	}
 
 	comment := &models.Comment{}
-	result := db.First(&comment, request.ID)
+	result := db.Preload("User").First(&comment, request.ID)
 	if result.Error != nil {
 		return errors.Wrap(result.Error, errors.DatabaseError)
 	}

--- a/pkg/queries/user.go
+++ b/pkg/queries/user.go
@@ -360,6 +360,7 @@ func GetProfile(db *gorm.DB, queriedUserID uint, queryingUserID uint) (models.Pr
 	displayInvitationCode := queryingUserID == queriedUserID
 	displayReward := queryingUserID == queriedUserID
 
+	// don't query if not logged in
 	if queryingUserID != 0 && queryingUserID != queriedUserID {
 		queryingUser, err := GetUserByID(db, queryingUserID)
 		if err != nil {

--- a/pkg/queries/user.go
+++ b/pkg/queries/user.go
@@ -357,8 +357,6 @@ func GetProfile(db *gorm.DB, queriedUserID uint, queryingUserID uint) (models.Pr
 		return models.ProfileResponse{}, err
 	}
 
-	// As written in the previous commit, administrators do not
-	// have access to the invitation code of users other than themselves.
 	displayInvitationCode := queryingUserID == queriedUserID
 	displayReward := queryingUserID == queriedUserID
 

--- a/pkg/queries/user.go
+++ b/pkg/queries/user.go
@@ -359,7 +359,7 @@ func GetProfile(db *gorm.DB, queriedUserID uint, queryingUserID uint) (models.Pr
 
 	// As written in the previous commit, administrators do not
 	// have access to the invitation code of users other than themselves.
-	var displayInvitationCode bool = queryingUserID == queriedUserID
+	displayInvitationCode := queryingUserID == queriedUserID
 	var displayReward bool = queryingUserID == queriedUserID
 
 	if queryingUserID != 0 && queryingUserID != queriedUserID {

--- a/pkg/queries/user.go
+++ b/pkg/queries/user.go
@@ -360,7 +360,7 @@ func GetProfile(db *gorm.DB, queriedUserID uint, queryingUserID uint) (models.Pr
 	// As written in the previous commit, administrators do not
 	// have access to the invitation code of users other than themselves.
 	displayInvitationCode := queryingUserID == queriedUserID
-	var displayReward bool = queryingUserID == queriedUserID
+	displayReward := queryingUserID == queriedUserID
 
 	if queryingUserID != 0 && queryingUserID != queriedUserID {
 		queryingUser, err := GetUserByID(db, queryingUserID)


### PR DESCRIPTION
- In `controllers/reward/setcomment.go`, User should be preloaded before looking up the comment.
- In `queries.GetProfile`, whether or not to display reward should be determined by the querying user, not whether the queried user is an administrator.